### PR TITLE
split todos by line endings: either CRLR or LR

### DIFF
--- a/pom
+++ b/pom
@@ -21,7 +21,7 @@ end
 
 def read_todos
   todos = File.read(ENV['TODO_FILE'])
-  todos.split($/)
+  todos.split(/\r?\n/)
 end
 
 def increase_pomos todos, index
@@ -41,7 +41,7 @@ def plan_task todos, index, planned
 end
 
 def puts_and_exit string
-  puts string 
+  puts string
   exit
 end
 


### PR DESCRIPTION
This splits a task correctly at the end of each line. In this case it does not matter if the line ends with CRLR (windows) or LR (unix)