### PR TITLE
add break message to tmux integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ A pomodoro counter implementation for [Todo.txt](http://todotxt.com/).
 ## Example:
 
 <img src="https://raw.github.com/metalelf0/pomodori-todo.txt/master/screenshot.png">
+
+## tmux integration:
+
+Add `set -g status-right "#(cat ~/.pomo.txt.tmux)"` to your `.tmux.conf`. This
+will put the time remaining in the current pomodoro in the right side of your
+status bar. See `man tmux` for further details on customizing this status.

--- a/lib/countdown.rb
+++ b/lib/countdown.rb
@@ -1,18 +1,29 @@
 class Countdown
   
   def run seconds, options={}
+    tmux_on = (options[:services] || []).include?(:tmux)
+    trap "SIGINT" do
+      clear_tmux() if tmux_on
+      exit 130
+    end
+    
     seconds.downto(0) do |current_seconds|
       sleep 1
-      write_tmux(current_seconds) if (options[:services] || []).include?(:tmux)
+      write_tmux(current_seconds) if tmux_on 
       set_window_title(current_seconds) if (options[:services] || []).include?(:iterm2)
       STDOUT.write "[RUNNING] #{to_minutes(current_seconds)}\r"
     end
+    clear_tmux() if tmux_on
   end
 
   private
 
   def write_tmux(current_seconds)
     `echo #{to_minutes(current_seconds, :tmux)} > ~/.pomo.txt.tmux` 
+  end
+
+  def clear_tmux()
+    `echo "break" > ~/.pomo.txt.tmux`
   end
 
   def set_window_title(current_seconds)

--- a/lib/terminal_notifier_logger.rb
+++ b/lib/terminal_notifier_logger.rb
@@ -1,9 +1,9 @@
 class TerminalNotifierLogger
   def notify_start task
-    TerminalNotifier.notify('Pomodoro started', title: 'Pomotxt', sound: 'Glass')
+    TerminalNotifier.notify("#{task.index} #{task.text}", title: 'Pomodoro Started', sound: 'Glass')
   end
 
   def notify_completed task
-    TerminalNotifier.notify('Pomodoro completed!', title: 'Pomotxt', sound: 'Glass')
+    TerminalNotifier.notify("#{task.index} #{task.text}", title: 'Pomodoro Completed!', sound: 'Glass')
   end
 end

--- a/pom
+++ b/pom
@@ -75,6 +75,7 @@ when 'start'
   todos = read_todos
   task_being_worked = Task.new(index + 1, todos[index])
   logger.log_pomodoro_started(task_being_worked)
+  task_being_worked.puts_highlighted
   Countdown.new.run(POMODORO_SECONDS, services: [ :tmux, :iterm2 ])
   logger.log_pomodoro_completed(task_being_worked)
   increase_pomos todos, index


### PR DESCRIPTION
tmux file will read "break" when the timer expires, or if the user interrupts the timer with Ctrl-C.

In addition, this adds a section to the readme on how to enable the tmux integration.