### PR TITLE
Support for i3blocks signalling and configurable seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ A pomodoro counter implementation for [Todo.txt](http://todotxt.com/).
 ## Example:
 
 <img src="https://raw.github.com/metalelf0/pomodori-todo.txt/master/screenshot.png">
+
+## tmux integration:
+
+Add `set -g status-right "#(cat ~/.pomo.txt.tmux)"` to your `.tmux.conf`. This
+will put the time remaining in the current pomodoro in the right side of your
+status bar. See `man tmux` for further details on customizing this status.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A pomodoro counter implementation for [Todo.txt](http://todotxt.com/).
 
 ## Usage:
 
-	todo.sh pomo action [task_number] [args]
+	todo.sh pom action [task_number] [args]
 	Actions:
 	  ls
 	     lists tasks with pomodori count and estimates

--- a/lib/countdown.rb
+++ b/lib/countdown.rb
@@ -1,39 +1,43 @@
 class Countdown
   
-  def run seconds, options={}
+  def run seconds, options={}  
     seconds.downto(0) do |current_seconds|
       sleep 1
-      write_tmux(current_seconds) if (options[:services] || []).include?(:tmux)
-      set_window_title(current_seconds) if (options[:services] || []).include?(:iterm2)
-      STDOUT.write "[RUNNING] #{to_minutes(current_seconds)}\r"
+      write_tmux(current_seconds, seconds) if (options[:services] || []).include?(:tmux)
+      set_window_title(current_seconds, seconds) if (options[:services] || []).include?(:iterm2)
+      STDOUT.write "[RUNNING] #{to_minutes(current_seconds, seconds)}\r"
+      if ENV.has_key?('POMODORO_SIG_SIGNAL') && ENV.has_key?('POMODORO_SIG_PROCESS')
+        system("pkill -RTMIN+" + ENV['POMODORO_SIG_SIGNAL'] + " " + ENV['POMODORO_SIG_PROCESS'])
+      end
     end
   end
 
   private
 
-  def write_tmux(current_seconds)
-    `echo #{to_minutes(current_seconds, :tmux)} > ~/.pomo.txt.tmux` 
+  def write_tmux(current_seconds, seconds)
+    `echo #{to_minutes(current_seconds, seconds, :tmux)} > ~/.pomo.txt.tmux` 
   end
 
-  def set_window_title(current_seconds)
-    title = to_minutes(current_seconds, :tmux)
+  def set_window_title(current_seconds, seconds)
+    title = to_minutes(current_seconds, seconds, :tmux)
     `echo -ne "\e]1;#{title}\a"`
   end
 
-  def to_minutes seconds, format=:standard
+  def to_minutes current_seconds, seconds, format=:standard
     minutes = seconds / 60
-    mins    = sprintf("%02d", minutes)
-    secs    = sprintf("%02d", seconds % 60)
+    current_minutes = current_seconds / 60
+    mins    = sprintf("%02d", current_minutes)
+    secs    = sprintf("%02d", current_seconds % 60)
     if format == :standard
-      "#{mins}:#{secs} [#{dots_for(minutes)}]"
+      "#{mins}:#{secs} [#{dots_for(current_minutes, minutes)}]"
     else
       "#{mins}:#{secs}"
     end
   end
 
 
-  def dots_for mins
-    "#{'.' * (25 - mins)}#{' ' * mins}"
+  def dots_for mins, overall
+    "#{'.' * (overall - mins)}#{' ' * mins}"
   end
 
 end

--- a/lib/countdown.rb
+++ b/lib/countdown.rb
@@ -1,18 +1,29 @@
 class Countdown
   
   def run seconds, options={}
+    tmux_on = (options[:services] || []).include?(:tmux)
+    trap "SIGINT" do
+      clear_tmux() if tmux_on
+      exit 130
+    end
+    
     seconds.downto(0) do |current_seconds|
       sleep 1
-      write_tmux(current_seconds) if (options[:services] || []).include?(:tmux)
+      write_tmux(current_seconds) if tmux_on 
       set_window_title(current_seconds) if (options[:services] || []).include?(:iterm2)
       STDOUT.write "[RUNNING] #{to_minutes(current_seconds)}\r"
     end
+    clear_tmux() if tmux_on
   end
 
   private
 
   def write_tmux(current_seconds)
     `echo #{to_minutes(current_seconds, :tmux)} > ~/.pomo.txt.tmux` 
+  end
+
+  def clear_tmux()
+    `echo "break" > ~/.pomo.txt.tmux`
   end
 
   def set_window_title(current_seconds)

--- a/lib/countdown.rb
+++ b/lib/countdown.rb
@@ -26,6 +26,9 @@ class Countdown
 
   def clear_tmux()
     `echo "break" > ~/.pomo.txt.tmux`
+    if ENV.has_key?('POMODORO_SIG_SIGNAL') && ENV.has_key?('POMODORO_SIG_PROCESS')
+      system("pkill -RTMIN+" + ENV['POMODORO_SIG_SIGNAL'] + " " + ENV['POMODORO_SIG_PROCESS'])
+    end
   end
 
   def set_window_title(current_seconds, seconds)

--- a/lib/file_logger.rb
+++ b/lib/file_logger.rb
@@ -1,9 +1,12 @@
+require 'fileutils'
+
 class FileLogger
 
   attr_accessor :pomodoro_log_file
 
   def initialize log_file_path
     @pomodoro_log_file = log_file_path 
+    FileUtils.touch pomodoro_log_file
   end
 
   def notify_start task
@@ -18,9 +21,9 @@ class FileLogger
   private
 
   def add_separator_if_new_day
+    return if File.zero?(pomodoro_log_file)
     last_day = File.open(pomodoro_log_file, "r")  { |file| file.readlines.last.split(" ")[0]}
     today    = Time.now.strftime('%Y/%m/%d')
     File.open(pomodoro_log_file, "a") { |file| file.puts "\n-----------\n\n" } if last_day != today
   end
-      
 end

--- a/lib/terminal_notifier_logger.rb
+++ b/lib/terminal_notifier_logger.rb
@@ -1,9 +1,9 @@
 class TerminalNotifierLogger
   def notify_start task
-    TerminalNotifier.notify('Pomodoro started', title: 'Pomotxt', sound: 'Glass')
+    TerminalNotifier.notify("#{task.index} #{task.text}", title: 'Pomodoro Started', sound: 'Glass')
   end
 
   def notify_completed task
-    TerminalNotifier.notify('Pomodoro completed!', title: 'Pomotxt', sound: 'Glass')
+    TerminalNotifier.notify("#{task.index} #{task.text}", title: 'Pomodoro Completed!', sound: 'Glass')
   end
 end

--- a/pom
+++ b/pom
@@ -21,7 +21,7 @@ end
 
 def read_todos
   todos = File.read(ENV['TODO_FILE'])
-  todos.split($/)
+  todos.split(/\r?\n/)
 end
 
 def increase_pomos todos, index
@@ -41,7 +41,7 @@ def plan_task todos, index, planned
 end
 
 def puts_and_exit string
-  puts string 
+  puts string
   exit
 end
 

--- a/pom
+++ b/pom
@@ -14,7 +14,25 @@ require_relative 'lib/linux_notifier_logger'
 require_relative 'lib/notifier_factory'
 require_relative 'lib/file_logger'
 
-POMODORO_SECONDS = 25 * 60
+#
+# ENVIRONMENT VARIABLES
+# 
+# The following variables can be set:
+#
+# POMODORO_SECONDS sets the duration for one pomodoro
+#
+# POMODORO_SIG_PROCESS a process to be signalled every second to update
+# POMODORO_SIG_SIGNAL the signal to be sent
+# This can be used for some custom notification, e.g. for i3blocks.
+# See: https://github.com/vivien/i3blocks
+#
+
+if ENV.has_key?('POMODORO_SECONDS')
+  POMODORO_SECONDS = ENV['POMODORO_SECONDS'].to_i
+else
+  POMODORO_SECONDS = 25 * 60
+end
+
 # TODO: either move this to a env variable or a yml configuration file
 POMODORO_LOG_FILE = "#{ENV['HOME']}/Documents/pomodoro_log.txt"
 
@@ -50,8 +68,12 @@ def puts_and_exit string
   exit
 end
 
+action = ARGV[1] || 'ls'
+if ENV.has_key?('POMODORO_SIG_SIGNAL') && ENV.has_key?('POMODORO_SIG_PROCESS')
+  system("pkill -RTMIN+#{ENV['POMODORO_SIG_SIGNAL']} #{ENV['POMODORO_SIG_PROCESS']}")
+end
 
-case ARGV[1]
+case action
 when 'ls'
   todos = read_todos
   todos.each_with_index do |todo, index|
@@ -83,6 +105,9 @@ when 'start'
   Countdown.new.run(POMODORO_SECONDS, services: [ :tmux, :iterm2 ])
   logger.log_pomodoro_completed(task_being_worked)
   increase_pomos todos, index
+  if ENV.has_key?('POMODORO_SIG_SIGNAL') && ENV.has_key?('POMODORO_SIG_PROCESS')
+    system("pkill -RTMIN+#{ENV['POMODORO_SIG_SIGNAL']} #{ENV['POMODORO_SIG_PROCESS']}")
+  end
 when 'help'
   puts "Usage: todo.sh pomo action [task_number] [args]\n"
   puts "Actions:"

--- a/pom
+++ b/pom
@@ -75,6 +75,7 @@ when 'start'
   todos = read_todos
   task_being_worked = Task.new(index + 1, todos[index])
   logger.log_pomodoro_started(task_being_worked)
+  task_being_worked.puts_highlighted
   Countdown.new.run(POMODORO_SECONDS, services: [ :tmux, :iterm2 ])
   logger.log_pomodoro_completed(task_being_worked)
   increase_pomos todos, index


### PR DESCRIPTION
Hi Andrea,

I use i3 as WM, and specifically i3blocks as status bar. i3blocks has the nice ability that a status update can be triggered by using unix process signals. This way, the current status has not to be polled constantly, especially not when not even a pomodori session is running.

So I implemented this signalling, based on environment variables. As you suggested in the code to use environment variables anyway, e.g. to configure the seconds, I decided to go for it and implemented the change for the seconds as well. This was actually a bigger change as you had 25 minutes hard-coded in the console output. 

I also changed the default behaviour of pom. Without an action, now pom ls is invoked.

Things to consider: 
- This can be used for any kind of process signalling, both process name and signal is configurable now.
- If the environment variables are not set, then nothing happens, so it is fully backwards compatible. 
- As of now, pkill is used to send the signal, so this is a dependency if the feature is to be used. 
- Untested on Mac, on Windows it will certainly not work (but should also not hurt).
- At least with my blocklet that shows the status, it is not clear that a pomodori-session is finished (probably I could check if the time in todo.txt.tmux is 0:00). So the last status with my task and time 0:00 remains on the status bar. I, however, like it this way, as I see then that the time is over. It gets removed when an update is triggered and the todo.txt.tmux file is not modified since more than 5 seconds. So I simply call todo.sh pom once to get it finally removed. That's why pom also signals when invoked (and then every second while the timer is running).

Hope you like it.

Cheers,

Kai