### PR TITLE
Pomodoro log file can be set as an env variable

### DIFF
--- a/pom
+++ b/pom
@@ -10,8 +10,7 @@ require_relative 'lib/terminal_notifier_logger'
 require_relative 'lib/file_logger'
 
 POMODORO_SECONDS = 25 * 60
-# TODO: either move this to a env variable or a yml configuration file
-POMODORO_LOG_FILE = "#{ENV['HOME']}/Documents/pomodoro_log.txt"
+POMODORO_LOG_FILE = ENV['POMODORO_LOG_FILE'] || "#{ENV['HOME']}/Documents/pomodoro_log.txt"
 
 def logger
   PomoLogger.new(


### PR DESCRIPTION
Hi,

I just needed to create the log file in another directory, so I'm proposing this minor change.
Thanks in advance.

Cheers,
Gilmar 